### PR TITLE
Improved local development setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+# Custom
+**/appsettings.Local.json
+
 # User-specific files
 *.rsuser
 *.suo

--- a/FoxHound.Web/Program.cs
+++ b/FoxHound.Web/Program.cs
@@ -7,7 +7,7 @@ using System.IO;
 
 namespace FoxHound.Web
 {
-    public class Program
+    public static class Program
     {
         public static void Main(string[] args)
         {
@@ -34,21 +34,27 @@ namespace FoxHound.Web
             Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
+                    webBuilder.ConfigureAppConfiguration(config => config.AddLocalAppSettings());
                     webBuilder.UseStartup<Startup>();
                 })
                 .UseSerilog();
 
-        public static IConfigurationBuilder GetCurrentConfiguration()
+        private static IConfigurationBuilder GetCurrentConfiguration()
         {
             var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production";
             var configuration = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
                 .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
                 .AddJsonFile($"appsettings.{environment}.json", optional: false, reloadOnChange: true)
-                .AddJsonFile("appsettings.Local.json", optional: true, reloadOnChange: true)
+                .AddLocalAppSettings()
                 .AddEnvironmentVariables();
 
             return configuration;
+        }
+
+        private static IConfigurationBuilder AddLocalAppSettings(this IConfigurationBuilder builder)
+        {
+            return builder.AddJsonFile("appsettings.Local.json", optional: true, reloadOnChange: true);
         }
 
         private static ILogger CreateLogger(IConfigurationRoot currentConfiguration)

--- a/FoxHound.Web/Program.cs
+++ b/FoxHound.Web/Program.cs
@@ -38,6 +38,19 @@ namespace FoxHound.Web
                 })
                 .UseSerilog();
 
+        public static IConfigurationBuilder GetCurrentConfiguration()
+        {
+            var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production";
+            var configuration = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+                .AddJsonFile($"appsettings.{environment}.json", optional: false, reloadOnChange: true)
+                .AddJsonFile("appsettings.Local.json", optional: true, reloadOnChange: true)
+                .AddEnvironmentVariables();
+
+            return configuration;
+        }
+
         private static ILogger CreateLogger(IConfigurationRoot currentConfiguration)
         {
             var logger = new LoggerConfiguration()
@@ -45,18 +58,6 @@ namespace FoxHound.Web
                 .CreateLogger();
 
             return logger;
-        }
-
-        private static IConfigurationBuilder GetCurrentConfiguration()
-        {
-            var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production";
-            var configuration = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
-                .AddJsonFile($"appsettings.{environment}.json", optional: false, reloadOnChange: true)
-                .AddEnvironmentVariables();
-
-            return configuration;
         }
     }
 }

--- a/FoxHound.Web/Startup.cs
+++ b/FoxHound.Web/Startup.cs
@@ -1,5 +1,3 @@
-using System;
-using System.IO;
 using FoxHound.App.Data;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/FoxHound.Web/Startup.cs
+++ b/FoxHound.Web/Startup.cs
@@ -10,9 +10,9 @@ namespace FoxHound.Web
 {
     public class Startup
     {
-        public Startup()
+        public Startup(IConfiguration configuration)
         {
-            Configuration = Program.GetCurrentConfiguration().Build();
+            Configuration = configuration;
         }
 
         public IConfiguration Configuration { get; }

--- a/FoxHound.Web/Startup.cs
+++ b/FoxHound.Web/Startup.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using FoxHound.App.Data;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -10,9 +12,9 @@ namespace FoxHound.Web
 {
     public class Startup
     {
-        public Startup(IConfiguration configuration)
+        public Startup()
         {
-            Configuration = configuration;
+            Configuration = Program.GetCurrentConfiguration().Build();
         }
 
         public IConfiguration Configuration { get; }

--- a/FoxHound.Web/appsettings.Development.json
+++ b/FoxHound.Web/appsettings.Development.json
@@ -7,7 +7,7 @@
       {
         "Name": "File",
         "Args": {
-          "path": "D:/_files/foxhound/logs/foxhound.log"
+          "path": "./logs/foxhound.log"
         }
       },
       {


### PR DESCRIPTION
- Made logging location more generic... FoxHound.Web/logs/foxhound.log (logs are ignored by version control)
  - This works for now. May need to change if hosted.
- Added support for appsettings.Local.json file which is not version controlled
  - Allows for developers to override appsettings.Development.json with different settings for their custom environment
  - This required rebuilding the configuration in Startup.cs. The configuration passed in from Program.cs to Startup.cs would not recognize appsettings.Local.json. I believe this is because the Program.cs CreateHostBuilder uses the default configuration settings. There may be a way to pass the configuration created in Program.cs to the Web Host Builder which would be cleaner, but I could not get it to work.