### PR TITLE
Better local setup config

### DIFF
--- a/FoxHound.Web/Program.cs
+++ b/FoxHound.Web/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Hosting;
 using Serilog;
 using System;
 using System.IO;
+using System.Linq;
 
 namespace FoxHound.Web
 {
@@ -34,11 +35,14 @@ namespace FoxHound.Web
             Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
+                    // Ensure startup receives all configuration, including all appsettings.x.json files
+                    var configurationRoot = new ConfigurationRoot(GetCurrentConfiguration().Build().Providers.ToList());
+                    webBuilder.ConfigureAppConfiguration(x => x.AddConfiguration(configurationRoot));
                     webBuilder.UseStartup<Startup>();
                 })
                 .UseSerilog();
 
-        public static IConfigurationBuilder GetCurrentConfiguration()
+        private static IConfigurationBuilder GetCurrentConfiguration()
         {
             var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production";
             var configuration = new ConfigurationBuilder()

--- a/FoxHound.Web/Program.cs
+++ b/FoxHound.Web/Program.cs
@@ -4,11 +4,10 @@ using Microsoft.Extensions.Hosting;
 using Serilog;
 using System;
 using System.IO;
-using System.Linq;
 
 namespace FoxHound.Web
 {
-    public class Program
+    public static class Program
     {
         public static void Main(string[] args)
         {
@@ -35,9 +34,7 @@ namespace FoxHound.Web
             Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
-                    // Ensure startup receives all configuration, including all appsettings.x.json files
-                    var configurationRoot = new ConfigurationRoot(GetCurrentConfiguration().Build().Providers.ToList());
-                    webBuilder.ConfigureAppConfiguration(x => x.AddConfiguration(configurationRoot));
+                    webBuilder.ConfigureAppConfiguration(config => config.AddLocalAppSettings());
                     webBuilder.UseStartup<Startup>();
                 })
                 .UseSerilog();
@@ -49,10 +46,15 @@ namespace FoxHound.Web
                 .SetBasePath(Directory.GetCurrentDirectory())
                 .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
                 .AddJsonFile($"appsettings.{environment}.json", optional: false, reloadOnChange: true)
-                .AddJsonFile("appsettings.Local.json", optional: true, reloadOnChange: true)
+                .AddLocalAppSettings()
                 .AddEnvironmentVariables();
 
             return configuration;
+        }
+
+        private static IConfigurationBuilder AddLocalAppSettings(this IConfigurationBuilder builder)
+        {
+            return builder.AddJsonFile("appsettings.Local.json", optional: true, reloadOnChange: true);
         }
 
         private static ILogger CreateLogger(IConfigurationRoot currentConfiguration)

--- a/FoxHound.Web/Startup.cs
+++ b/FoxHound.Web/Startup.cs
@@ -10,9 +10,9 @@ namespace FoxHound.Web
 {
     public class Startup
     {
-        public Startup()
+        public Startup(IConfiguration configuration)
         {
-            Configuration = Program.GetCurrentConfiguration().Build();
+            Configuration = configuration;
         }
 
         public IConfiguration Configuration { get; }


### PR DESCRIPTION
There's a couple ways of ensuring that the appsettings.local.json file gets passed into startup.cs. I found this was the most explicit way and tried to name things such that it was relatively discoverable/understandable as to what is happening.

Note: This PR goes back into the better-local-setup branch. If we like what's here, we can merge this into that branch, then merge that branch into master.