### PR TITLE
CreateBlog Fluent Validation

### DIFF
--- a/FoxHound.App.Tests/Blogs/CreateBlog/CreateBlogCommandValidatorTests.cs
+++ b/FoxHound.App.Tests/Blogs/CreateBlog/CreateBlogCommandValidatorTests.cs
@@ -1,0 +1,38 @@
+using AutoFixture;
+using AutoFixture.AutoMoq;
+using FluentValidation.TestHelper;
+using FoxHound.App.Blogs.CreateBlog;
+using FoxHound.App.Data;
+using Microsoft.EntityFrameworkCore;
+using System;
+using Xunit;
+
+namespace FoxHound.App.Tests.Blogs.CreateBlog
+{
+    public class CreateBlogCommandValidatorTests
+    {
+        private readonly IFixture _fixture;
+        private readonly IFoxHoundData _foxHoundData;
+        private readonly DbContextOptions<FoxHoundData> _dbContextOptions;
+
+        public CreateBlogCommandValidatorTests()
+        {
+            _fixture = new Fixture();
+            _fixture.Customize(new AutoMoqCustomization());
+
+            _dbContextOptions = new DbContextOptionsBuilder<FoxHoundData>().UseInMemoryDatabase(Guid.NewGuid().ToString()).Options;
+            _foxHoundData = new FoxHoundData(_dbContextOptions);
+            _fixture.Inject(_foxHoundData);
+        }
+
+        [Fact]
+        public void Owner_IsEmpty_FailsValidation()
+        {
+            // Arrange
+            var validator = _fixture.Create<CreateBlogCommandValidator>();
+
+            // Act / Assert
+            validator.ShouldHaveValidationErrorFor(x => x.Owner, string.Empty).WithErrorMessage("Owner is required");
+        }
+    }
+}

--- a/FoxHound.App.Tests/Blogs/CreateBlog/CreateBlogCommandValidatorTests.cs
+++ b/FoxHound.App.Tests/Blogs/CreateBlog/CreateBlogCommandValidatorTests.cs
@@ -2,9 +2,6 @@ using AutoFixture;
 using AutoFixture.AutoMoq;
 using FluentValidation.TestHelper;
 using FoxHound.App.Blogs.CreateBlog;
-using FoxHound.App.Data;
-using Microsoft.EntityFrameworkCore;
-using System;
 using Xunit;
 
 namespace FoxHound.App.Tests.Blogs.CreateBlog
@@ -12,17 +9,11 @@ namespace FoxHound.App.Tests.Blogs.CreateBlog
     public class CreateBlogCommandValidatorTests
     {
         private readonly IFixture _fixture;
-        private readonly IFoxHoundData _foxHoundData;
-        private readonly DbContextOptions<FoxHoundData> _dbContextOptions;
 
         public CreateBlogCommandValidatorTests()
         {
             _fixture = new Fixture();
             _fixture.Customize(new AutoMoqCustomization());
-
-            _dbContextOptions = new DbContextOptionsBuilder<FoxHoundData>().UseInMemoryDatabase(Guid.NewGuid().ToString()).Options;
-            _foxHoundData = new FoxHoundData(_dbContextOptions);
-            _fixture.Inject(_foxHoundData);
         }
 
         [Fact]
@@ -33,6 +24,16 @@ namespace FoxHound.App.Tests.Blogs.CreateBlog
 
             // Act / Assert
             validator.ShouldHaveValidationErrorFor(x => x.Owner, string.Empty).WithErrorMessage("Owner is required");
+        }
+
+        [Fact]
+        public void Owner_IsGreaterThan20Characters_FailsValidation()
+        {
+            // Arrange
+            var validator = _fixture.Create<CreateBlogCommandValidator>();
+
+            // Act / Assert
+            validator.ShouldHaveValidationErrorFor(x => x.Owner, new string('*', 21)).WithErrorMessage("Owner must be less than or equal to 20 characters");
         }
     }
 }

--- a/FoxHound.App/Blogs/CreateBlog/CreateBlogCommandValidator.cs
+++ b/FoxHound.App/Blogs/CreateBlog/CreateBlogCommandValidator.cs
@@ -1,0 +1,13 @@
+﻿using FluentValidation;
+
+namespace FoxHound.App.Blogs.CreateBlog
+{
+    public class CreateBlogCommandValidator : AbstractValidator<CreateBlogCommand>
+    {
+        public CreateBlogCommandValidator()
+        {
+            RuleFor(x => x.Owner)
+                .NotEmpty().WithMessage("Owner is required");
+        }
+    }
+}

--- a/FoxHound.App/Blogs/CreateBlog/CreateBlogCommandValidator.cs
+++ b/FoxHound.App/Blogs/CreateBlog/CreateBlogCommandValidator.cs
@@ -7,7 +7,8 @@ namespace FoxHound.App.Blogs.CreateBlog
         public CreateBlogCommandValidator()
         {
             RuleFor(x => x.Owner)
-                .NotEmpty().WithMessage("Owner is required");
+                .NotEmpty().WithMessage("Owner is required")
+                .MaximumLength(20).WithMessage("Owner must be less than or equal to {MaxLength} characters");
         }
     }
 }

--- a/FoxHound.App/FoxHound.App.csproj
+++ b/FoxHound.App/FoxHound.App.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="8.6.2" />
     <PackageReference Include="MediatR" Version="8.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.3">


### PR DESCRIPTION
Currently, only a CreateBlog Command exists for Fluent Validation setup. GetAllBlogs is setup as Query Handler where I don't recall us setting up validation for this type (only commands). Can you please review and let me know if I missed anything.