### PR TITLE
Add ApplicationInsights client metrics capture

### DIFF
--- a/FoxHound.Client/package-lock.json
+++ b/FoxHound.Client/package-lock.json
@@ -1078,105 +1078,96 @@
         "react-is": "^16.8.0"
       }
     },
-    "@material/animation": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-5.1.0.tgz",
-      "integrity": "sha512-qZuPCZkTsCQCzx5EtY2eNBcmYOMGMbFVq6VTmvQztDCYDykT8JfP8Hpk55Y5bGORHvBbIasUXzoAhfQs6w/Bdg==",
+    "@microsoft/applicationinsights-analytics-js": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.5.4.tgz",
+      "integrity": "sha512-Eda0bcThQJA/zNVzmU3+Vo9WJT/55LzUxpEATOCB6BbN1uGGUp3hGOdlV/hRl652TPutXII/gvhg8Z4uqq+VsA==",
       "requires": {
-        "tslib": "^1.9.3"
+        "@microsoft/applicationinsights-common": "2.5.4",
+        "@microsoft/applicationinsights-core-js": "2.5.4",
+        "@microsoft/dynamicproto-js": "^0.5.2",
+        "tslib": "^1.11.1"
       }
     },
-    "@material/base": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@material/base/-/base-5.1.0.tgz",
-      "integrity": "sha512-UxVFKpSNaoKqd7hHxy9hrvwANp0WJy/BZqu8Rj/aRvKnBZnuHehFuOysI9WqdeTqgveJaQoj6EEkVEqLurR5Sg==",
+    "@microsoft/applicationinsights-channel-js": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.5.4.tgz",
+      "integrity": "sha512-xDgI+7LAT5xPdxbBu/fueufH/j7p+hqfPJkkyG9BYdLa77mp+UfnP1kKjthcsdrhJiVIAbx08hmZpo72espIng==",
       "requires": {
-        "tslib": "^1.9.3"
+        "@microsoft/applicationinsights-common": "2.5.4",
+        "@microsoft/applicationinsights-core-js": "2.5.4",
+        "tslib": "^1.11.1"
       }
     },
-    "@material/dom": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-5.1.0.tgz",
-      "integrity": "sha512-tBbl3hG34Auv+2sboWhtstXeZ9rx3G7hb/jEXs5xZ5KIfZHwY4mbo0KqR/fSJZKaUsvk2Nc/UEOVcUx2mTNmYg==",
+    "@microsoft/applicationinsights-common": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.5.4.tgz",
+      "integrity": "sha512-lrLwBUKqK4SZq2nCegUs/O8Ew2KPtL+JUCARoo6YdT8vSiUSxVk+XvwnMOViv27+NWsM3HpqOcjMn+C3kwULZQ==",
       "requires": {
-        "tslib": "^1.9.3"
+        "@microsoft/applicationinsights-core-js": "2.5.4",
+        "tslib": "^1.11.1"
       }
     },
-    "@material/elevation": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-5.1.0.tgz",
-      "integrity": "sha512-NsWIT+L6x3BLouCOh3H8x885/nCrNNmzCwHEodz/0PcYQsxx9RiIVFkagmJWw/w//jej/D4NotD0xHGKOWTrFA==",
+    "@microsoft/applicationinsights-core-js": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.5.4.tgz",
+      "integrity": "sha512-U3spLDr99R8X7X7VH49RJhx7KhB8HZpKo7rb3ymFG6z6hB7eWQQyLyMsFnThNJI3sVqwEPCQd7dBs7viheLqjw==",
       "requires": {
-        "@material/animation": "^5.1.0",
-        "@material/base": "^5.1.0",
-        "@material/feature-targeting": "^5.1.0",
-        "@material/theme": "^5.1.0"
+        "@microsoft/dynamicproto-js": "^0.5.2",
+        "tslib": "^1.11.1"
       }
     },
-    "@material/feature-targeting": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-5.1.0.tgz",
-      "integrity": "sha512-z3JNWF7lP9WOzw1xBwul/HAOu4qC6EpK/8MkhjLNI9APvdYML82PWS1V0k0MiqA6Jk6uxm8DiVAk9VUqBa9/YA=="
-    },
-    "@material/ripple": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-5.1.0.tgz",
-      "integrity": "sha512-mluIf+HaaCplszp9/MAl178FpfIJWi5hSyQOpF7w8RTzRSaH8J0uwgmn8VeNnwe1TAWio0vQzHrz4iEg2r7Ngw==",
+    "@microsoft/applicationinsights-dependencies-js": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.5.4.tgz",
+      "integrity": "sha512-C01PkF7nQSYFpHiTo4Ltz5VOJqyTaQMHk2fNLBnyxLF2VhSUlfowPhyS6mGU3miscd5sQuktrlYol7LqjiRCXw==",
       "requires": {
-        "@material/animation": "^5.1.0",
-        "@material/base": "^5.1.0",
-        "@material/dom": "^5.1.0",
-        "@material/feature-targeting": "^5.1.0",
-        "@material/theme": "^5.1.0",
-        "tslib": "^1.9.3"
+        "@microsoft/applicationinsights-common": "2.5.4",
+        "@microsoft/applicationinsights-core-js": "2.5.4",
+        "@microsoft/dynamicproto-js": "^0.5.2",
+        "tslib": "^1.11.1"
       }
     },
-    "@material/rtl": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-5.1.0.tgz",
-      "integrity": "sha512-Hij4KJIfjK63HArdQ3K1INMo0MbigDgL0JhjO1VDk5c+iYmYpjDI7wgPLmV5ISCBtenXRWpo1xbBO3uEmtCd4Q=="
-    },
-    "@material/shape": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@material/shape/-/shape-5.1.0.tgz",
-      "integrity": "sha512-/k27T9fhQ1zj7VCsS26nv0TzsOi142ncik2mycEXq8753PDBotob7Y19pbwivwt9QxkglhMGH0EaWdZPzBoQXw==",
+    "@microsoft/applicationinsights-properties-js": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.5.4.tgz",
+      "integrity": "sha512-2ueiQYhMiNIf9Iua7zrUGIDBiO8zPLau1yBePqLvEQ2CewBE9ZrTbdqhzpBrUQUKFbmWlETXYsIWQNz+T2rRfw==",
       "requires": {
-        "@material/feature-targeting": "^5.1.0",
-        "@material/rtl": "^5.1.0"
+        "@microsoft/applicationinsights-common": "2.5.4",
+        "@microsoft/applicationinsights-core-js": "2.5.4",
+        "tslib": "^1.11.1"
       }
     },
-    "@material/theme": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-5.1.0.tgz",
-      "integrity": "sha512-VoaCYAubn/oEG1/fu/yP4nxAw8sLEphFOGGBJxcPGQoLgQ9qcvibsV3G5H9S6AtmhJxgSGU0JnO9TaiuhQq5zA==",
+    "@microsoft/applicationinsights-react-js": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-react-js/-/applicationinsights-react-js-2.5.4.tgz",
+      "integrity": "sha512-BB8Od5ikGYkaN6VqxciUycfF3xY/8V2/sdoIyLZVz4310kQLamogwQtcMu1bb3gI9qpreSD/JzkiSSQa9GkQ2g==",
       "requires": {
-        "@material/feature-targeting": "^5.1.0"
+        "@microsoft/applicationinsights-common": "2.5.4",
+        "@microsoft/applicationinsights-core-js": "2.5.4",
+        "history": "^4.9.0",
+        "tslib": "^1.11.1"
       }
     },
-    "@material/top-app-bar": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@material/top-app-bar/-/top-app-bar-5.1.0.tgz",
-      "integrity": "sha512-ySCUpwIFnCmY/I9/XPs0IPBCvjWzc2NQ7mquG7qQoaUVUqWTNMyL15zG6CeDf2/Nk14mlSRNM4LRPFWenCdJoQ==",
+    "@microsoft/applicationinsights-web": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-2.5.4.tgz",
+      "integrity": "sha512-5nBgxEDkM61E0irdi78DcEwfiLvYueyU5tQsCxovPfhbt5Ub8KzzT8cvmrh6p9Rt9DcpKP/uHD8k6OqMvdgvVg==",
       "requires": {
-        "@material/animation": "^5.1.0",
-        "@material/base": "^5.1.0",
-        "@material/elevation": "^5.1.0",
-        "@material/ripple": "^5.1.0",
-        "@material/rtl": "^5.1.0",
-        "@material/shape": "^5.1.0",
-        "@material/theme": "^5.1.0",
-        "@material/typography": "^5.1.0",
-        "tslib": "^1.9.3"
+        "@microsoft/applicationinsights-analytics-js": "2.5.4",
+        "@microsoft/applicationinsights-channel-js": "2.5.4",
+        "@microsoft/applicationinsights-common": "2.5.4",
+        "@microsoft/applicationinsights-core-js": "2.5.4",
+        "@microsoft/applicationinsights-dependencies-js": "2.5.4",
+        "@microsoft/applicationinsights-properties-js": "2.5.4",
+        "@microsoft/dynamicproto-js": "^0.5.2",
+        "tslib": "^1.11.1"
       }
     },
-    "@material/typography": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@material/typography/-/typography-5.1.0.tgz",
-      "integrity": "sha512-yh02koa6JLyPT5u7Zb31kyqhoZoppL0n9FmZK+eHXZcfeDF7ROL0UmtRsEjQxfnCNZRR+FIhAgrzdYxClwH05g==",
-      "requires": {
-        "@material/feature-targeting": "^5.1.0",
-        "@material/theme": "^5.1.0"
-      }
+    "@microsoft/dynamicproto-js": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-0.5.2.tgz",
+      "integrity": "sha512-tGwZJLtLVK96OKl5/pHeZFgi28rnKJB2DQ0V/28SVQnv9tC/OXCNOrvvvtIZM6wp1YJwqVSFnyp46w3azDjC0Q=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",

--- a/FoxHound.Client/package.json
+++ b/FoxHound.Client/package.json
@@ -28,7 +28,9 @@
     "react-app-polyfill": "^1.0.6",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.1.2",
-    "react-simplemde-editor": "^4.1.0"
+    "react-simplemde-editor": "^4.1.0",
+    "@microsoft/applicationinsights-web": "2.5.4",
+    "@microsoft/applicationinsights-react-js": "2.5.4"
   },
   "browerslist": [
     "last 1 Chrome versions",

--- a/FoxHound.Client/src/.env
+++ b/FoxHound.Client/src/.env
@@ -1,1 +1,2 @@
 API_URL=https://localhost:44360/api
+APP_INSIGHTS_INSTRUMENTATION_KEY=

--- a/FoxHound.Client/src/App.tsx
+++ b/FoxHound.Client/src/App.tsx
@@ -4,27 +4,9 @@ import React from "react";
 import ReactDOM from "react-dom";
 import NavDrawer from "./Navigation/NavDrawer";
 import { BrowserRouter as Router } from "react-router-dom";
-import { ApplicationInsights } from "@microsoft/applicationinsights-web";
-import {
-  ReactPlugin,
-  withAITracking,
-} from "@microsoft/applicationinsights-react-js";
-import { createBrowserHistory } from "history";
+import withAppInsights from "./Utility/AppInsights";
 
-const browserHistory = createBrowserHistory({ basename: "" });
-const reactPlugin = new ReactPlugin();
-const appInsights = new ApplicationInsights({
-  config: {
-    instrumentationKey: process.env.APP_INSIGHTS_INSTRUMENTATION_KEY,
-    extensions: [reactPlugin],
-    extensionConfig: {
-      [reactPlugin.identifier]: { history: browserHistory },
-    },
-  },
-});
-appInsights.loadAppInsights();
-
-const App: React.ComponentClass = withAITracking(reactPlugin, () => {
+const App: React.ComponentClass = withAppInsights(() => {
   return (
     <Router>
       <NavDrawer />

--- a/FoxHound.Client/src/App.tsx
+++ b/FoxHound.Client/src/App.tsx
@@ -4,13 +4,32 @@ import React from "react";
 import ReactDOM from "react-dom";
 import NavDrawer from "./Navigation/NavDrawer";
 import { BrowserRouter as Router } from "react-router-dom";
+import { ApplicationInsights } from "@microsoft/applicationinsights-web";
+import {
+  ReactPlugin,
+  withAITracking,
+} from "@microsoft/applicationinsights-react-js";
+import { createBrowserHistory } from "history";
 
-const App: React.FC = () => {
+const browserHistory = createBrowserHistory({ basename: "" });
+const reactPlugin = new ReactPlugin();
+const appInsights = new ApplicationInsights({
+  config: {
+    instrumentationKey: process.env.APP_INSIGHTS_INSTRUMENTATION_KEY,
+    extensions: [reactPlugin],
+    extensionConfig: {
+      [reactPlugin.identifier]: { history: browserHistory },
+    },
+  },
+});
+appInsights.loadAppInsights();
+
+const App: React.ComponentClass = withAITracking(reactPlugin, () => {
   return (
     <Router>
       <NavDrawer />
     </Router>
   );
-};
+});
 
 ReactDOM.render(<App />, document.getElementById("root"));

--- a/FoxHound.Client/src/Utility/AppInsights.ts
+++ b/FoxHound.Client/src/Utility/AppInsights.ts
@@ -1,0 +1,23 @@
+import { ApplicationInsights } from "@microsoft/applicationinsights-web";
+import {
+  ReactPlugin,
+  withAITracking,
+} from "@microsoft/applicationinsights-react-js";
+import { createBrowserHistory } from "history";
+
+const browserHistory = createBrowserHistory({ basename: "" });
+const reactPlugin = new ReactPlugin();
+const ai = new ApplicationInsights({
+  config: {
+    instrumentationKey: process.env.APP_INSIGHTS_INSTRUMENTATION_KEY,
+    extensions: [reactPlugin],
+    extensionConfig: {
+      [reactPlugin.identifier]: { history: browserHistory },
+    },
+  },
+});
+ai.loadAppInsights();
+
+export default (Component: React.FC) => withAITracking(reactPlugin, Component);
+export const appInsights = ai.appInsights;
+export { reactPlugin };


### PR DESCRIPTION
I verified this against an AppInsights resource that I have and it is logging metrics.  I followed the documentation somewhat from [here](https://docs.microsoft.com/en-us/azure/azure-monitor/app/javascript) and [here](https://github.com/microsoft/ApplicationInsights-JS/blob/17ef50442f73fd02a758fbd74134933d92607ecf/extensions/applicationinsights-react-js/README.md).  However, the React plugin for app insights specifically talks about metrics for class based components.  Nowhere does it discuss components using hooks.  I'm still very green with React so perhaps someone has a different interpretation of these docs.