### PR TITLE
Base Validators for Add and Update Blog Commands

### DIFF
--- a/FoxHound.App.Tests/Blogs/Common/CommonBlogCommandValidatorTests.cs
+++ b/FoxHound.App.Tests/Blogs/Common/CommonBlogCommandValidatorTests.cs
@@ -1,0 +1,71 @@
+﻿using AutoFixture;
+using AutoFixture.AutoMoq;
+using FluentValidation.TestHelper;
+using FoxHound.App.Blogs.Common;
+using Moq;
+using Xunit;
+
+namespace FoxHound.App.Tests.Blogs.Common
+{
+    public class CommonBlogCommandValidatorTests
+    {
+        private readonly IFixture _fixture;
+        private readonly Mock<IBlogCommand> _blogMock;
+
+        public CommonBlogCommandValidatorTests()
+        {
+            _fixture = new Fixture();
+            _fixture.Customize(new AutoMoqCustomization());
+
+            _blogMock = new Mock<IBlogCommand>();
+        }
+
+        [Fact]
+        public void Title_IsEmpty_FailsValidation()
+        {
+            // Arrange
+            _blogMock.Setup(x => x.Title).Returns(string.Empty);
+
+            var validator = _fixture.Create<CommonBlogCommandValidator>();
+
+            // Act / Assert
+            validator.ShouldHaveValidationErrorFor(x => x.Title, _blogMock.Object).WithErrorMessage("Title is required");
+        }
+
+        [Fact]
+        public void Title_IsGreaterThan128Characters_FailsValidation()
+        {
+            // Arrange
+            _blogMock.Setup(x => x.Title).Returns(new string('*', 129));
+
+            var validator = _fixture.Create<CommonBlogCommandValidator>();
+
+            // Act / Assert
+            validator.ShouldHaveValidationErrorFor(x => x.Title, _blogMock.Object).WithErrorMessage("Title must be less than or equal to 128 characters");
+        }
+
+        [Fact]
+        public void Owner_IsEmpty_FailsValidation()
+        {
+            // Arrange
+            _blogMock.Setup(x => x.Owner).Returns(string.Empty);
+
+            var validator = _fixture.Create<CommonBlogCommandValidator>();
+
+            // Act / Assert
+            validator.ShouldHaveValidationErrorFor(x => x.Owner, _blogMock.Object).WithErrorMessage("Owner is required");
+        }
+
+        [Fact]
+        public void Owner_IsGreaterThan128Characters_FailsValidation()
+        {
+            // Arrange
+            _blogMock.Setup(x => x.Owner).Returns(new string('*', 21));
+
+            var validator = _fixture.Create<CommonBlogCommandValidator>();
+
+            // Act / Assert
+            validator.ShouldHaveValidationErrorFor(x => x.Owner, _blogMock.Object).WithErrorMessage("Owner must be less than or equal to 20 characters");
+        }
+    }
+}

--- a/FoxHound.App.Tests/Blogs/CreateBlog/CreateBlogCommandValidatorTests.cs
+++ b/FoxHound.App.Tests/Blogs/CreateBlog/CreateBlogCommandValidatorTests.cs
@@ -3,6 +3,11 @@ using AutoFixture.AutoMoq;
 using FluentValidation.TestHelper;
 using FoxHound.App.Blogs.Common;
 using FoxHound.App.Blogs.CreateBlog;
+using FoxHound.App.Data;
+using FoxHound.App.Domain;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace FoxHound.App.Tests.Blogs.CreateBlog
@@ -10,11 +15,17 @@ namespace FoxHound.App.Tests.Blogs.CreateBlog
     public class CreateBlogCommandValidatorTests
     {
         private readonly IFixture _fixture;
+        private readonly IFoxHoundData _foxHoundData;
+        private readonly DbContextOptions<FoxHoundData> _dbContextOptions;
 
         public CreateBlogCommandValidatorTests()
         {
             _fixture = new Fixture();
             _fixture.Customize(new AutoMoqCustomization());
+
+            _dbContextOptions = new DbContextOptionsBuilder<FoxHoundData>().UseInMemoryDatabase(Guid.NewGuid().ToString()).Options;
+            _foxHoundData = new FoxHoundData(_dbContextOptions);
+            _fixture.Inject(_foxHoundData);
         }
 
         [Fact]
@@ -25,6 +36,24 @@ namespace FoxHound.App.Tests.Blogs.CreateBlog
 
             // Act / Assert
             validator.ShouldHaveChildValidator(x => x, typeof(CommonBlogCommandValidator));
+        }
+
+        [Fact]
+        public async Task CreateBlog_OwnerIsPartOfDifferentBlog_FailsValidation()
+        {
+            // Arrange
+            var owner = _fixture.Create<string>().Substring(0, 20);
+
+            var blogWithSameOwner = _fixture.Create<Blog>();
+            blogWithSameOwner.SetOwner(owner);
+            _foxHoundData.Blogs.Add(blogWithSameOwner);
+
+            await _foxHoundData.SaveChangesAsync();
+
+            var validator = _fixture.Create<CreateBlogCommandValidator>();
+
+            // Act / Assert
+            validator.ShouldHaveValidationErrorFor(x => x.Owner, owner).WithErrorMessage("Owner already in use for a Blog");
         }
     }
 }

--- a/FoxHound.App.Tests/Blogs/CreateBlog/CreateBlogCommandValidatorTests.cs
+++ b/FoxHound.App.Tests/Blogs/CreateBlog/CreateBlogCommandValidatorTests.cs
@@ -1,6 +1,7 @@
 ﻿using AutoFixture;
 using AutoFixture.AutoMoq;
 using FluentValidation.TestHelper;
+using FoxHound.App.Blogs.Common;
 using FoxHound.App.Blogs.CreateBlog;
 using Xunit;
 
@@ -17,43 +18,13 @@ namespace FoxHound.App.Tests.Blogs.CreateBlog
         }
 
         [Fact]
-        public void Title_IsEmpty_FailsValidation()
+        public void CreateBlogCommand_CallsCommonCommandValidator()
         {
             // Arrange
             var validator = _fixture.Create<CreateBlogCommandValidator>();
 
             // Act / Assert
-            validator.ShouldHaveValidationErrorFor(x => x.Title, string.Empty).WithErrorMessage("Title is required");
-        }
-
-        [Fact]
-        public void Title_IsGreaterThan128Characters_FailsValidation()
-        {
-            // Arrange
-            var validator = _fixture.Create<CreateBlogCommandValidator>();
-
-            // Act / Assert
-            validator.ShouldHaveValidationErrorFor(x => x.Title, new string('*', 129)).WithErrorMessage("Title must be less than or equal to 128 characters");
-        }
-
-        [Fact]
-        public void Owner_IsEmpty_FailsValidation()
-        {
-            // Arrange
-            var validator = _fixture.Create<CreateBlogCommandValidator>();
-
-            // Act / Assert
-            validator.ShouldHaveValidationErrorFor(x => x.Owner, string.Empty).WithErrorMessage("Owner is required");
-        }
-
-        [Fact]
-        public void Owner_IsGreaterThan20Characters_FailsValidation()
-        {
-            // Arrange
-            var validator = _fixture.Create<CreateBlogCommandValidator>();
-
-            // Act / Assert
-            validator.ShouldHaveValidationErrorFor(x => x.Owner, new string('*', 21)).WithErrorMessage("Owner must be less than or equal to 20 characters");
+            validator.ShouldHaveChildValidator(x => x, typeof(CommonBlogCommandValidator));
         }
     }
 }

--- a/FoxHound.App.Tests/Blogs/UpdateBlog/UpdateBlogCommandValidatorTests.cs
+++ b/FoxHound.App.Tests/Blogs/UpdateBlog/UpdateBlogCommandValidatorTests.cs
@@ -3,6 +3,11 @@ using AutoFixture.AutoMoq;
 using FluentValidation.TestHelper;
 using FoxHound.App.Blogs.Common;
 using FoxHound.App.Blogs.UpdateBlog;
+using FoxHound.App.Data;
+using FoxHound.App.Domain;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace FoxHound.App.Tests.Blogs.UpdateBlog
@@ -10,11 +15,17 @@ namespace FoxHound.App.Tests.Blogs.UpdateBlog
     public class UpdateBlogCommandValidatorTests
     {
         private readonly IFixture _fixture;
+        private readonly IFoxHoundData _foxHoundData;
+        private readonly DbContextOptions<FoxHoundData> _dbContextOptions;
 
         public UpdateBlogCommandValidatorTests()
         {
             _fixture = new Fixture();
             _fixture.Customize(new AutoMoqCustomization());
+
+            _dbContextOptions = new DbContextOptionsBuilder<FoxHoundData>().UseInMemoryDatabase(Guid.NewGuid().ToString()).Options;
+            _foxHoundData = new FoxHoundData(_dbContextOptions);
+            _fixture.Inject(_foxHoundData);
         }
 
         [Fact]
@@ -35,6 +46,57 @@ namespace FoxHound.App.Tests.Blogs.UpdateBlog
 
             // Act / Assert
             validator.ShouldHaveChildValidator(x => x, typeof(CommonBlogCommandValidator));
+        }
+
+        [Fact]
+        public async Task UpdateBlog_OwnerIsPartOfThisBlog_PassesFailsValidation()
+        {
+            // Arrange
+            var owner = _fixture.Create<string>().Substring(0, 20);
+
+            var thisBlog = _fixture.Create<Blog>();
+            thisBlog.SetOwner(owner);
+            _foxHoundData.Blogs.Add(thisBlog);
+
+            await _foxHoundData.SaveChangesAsync();
+
+            var updateBlogCommand = new UpdateBlogCommand
+            {
+                BlogId = thisBlog.BlogId,
+                Owner = owner
+            };
+
+            var validator = _fixture.Create<UpdateBlogCommandValidator>();
+
+            // Act / Assert
+            validator.ShouldNotHaveValidationErrorFor(x => x.Owner, updateBlogCommand);
+        }
+
+        [Fact]
+        public async Task UpdateBlog_OwnerIsPartOfDifferentBlog_FailsValidation()
+        {
+            // Arrange
+            var owner = _fixture.Create<string>().Substring(0, 20);
+
+            var thisBlog = _fixture.Create<Blog>();
+            _foxHoundData.Blogs.Add(thisBlog);
+
+            var differentBlog = _fixture.Create<Blog>();
+            differentBlog.SetOwner(owner);
+            _foxHoundData.Blogs.Add(differentBlog);
+
+            await _foxHoundData.SaveChangesAsync();
+
+            var updateBlogCommand = new UpdateBlogCommand
+            {
+                BlogId = thisBlog.BlogId,
+                Owner = owner
+            };
+
+            var validator = _fixture.Create<UpdateBlogCommandValidator>();
+
+            // Act / Assert
+            validator.ShouldHaveValidationErrorFor(x => x.Owner, updateBlogCommand).WithErrorMessage("Owner already in use for a Blog");
         }
     }
 }

--- a/FoxHound.App.Tests/Blogs/UpdateBlog/UpdateBlogCommandValidatorTests.cs
+++ b/FoxHound.App.Tests/Blogs/UpdateBlog/UpdateBlogCommandValidatorTests.cs
@@ -1,6 +1,7 @@
 ﻿using AutoFixture;
 using AutoFixture.AutoMoq;
 using FluentValidation.TestHelper;
+using FoxHound.App.Blogs.Common;
 using FoxHound.App.Blogs.UpdateBlog;
 using Xunit;
 
@@ -27,43 +28,13 @@ namespace FoxHound.App.Tests.Blogs.UpdateBlog
         }
 
         [Fact]
-        public void Title_IsEmpty_FailsValidation()
+        public void UpdateBlogCommand_CallsCommonCommandValidator()
         {
             // Arrange
             var validator = _fixture.Create<UpdateBlogCommandValidator>();
 
             // Act / Assert
-            validator.ShouldHaveValidationErrorFor(x => x.Title, string.Empty).WithErrorMessage("Title is required");
-        }
-
-        [Fact]
-        public void Title_IsGreaterThan128Characters_FailsValidation()
-        {
-            // Arrange
-            var validator = _fixture.Create<UpdateBlogCommandValidator>();
-
-            // Act / Assert
-            validator.ShouldHaveValidationErrorFor(x => x.Title, new string('*', 129)).WithErrorMessage("Title must be less than or equal to 128 characters");
-        }
-
-        [Fact]
-        public void Owner_IsEmpty_FailsValidation()
-        {
-            // Arrange
-            var validator = _fixture.Create<UpdateBlogCommandValidator>();
-
-            // Act / Assert
-            validator.ShouldHaveValidationErrorFor(x => x.Owner, string.Empty).WithErrorMessage("Owner is required");
-        }
-
-        [Fact]
-        public void Owner_IsGreaterThan128Characters_FailsValidation()
-        {
-            // Arrange
-            var validator = _fixture.Create<UpdateBlogCommandValidator>();
-
-            // Act / Assert
-            validator.ShouldHaveValidationErrorFor(x => x.Owner, new string('*', 21)).WithErrorMessage("Owner must be less than or equal to 20 characters");
+            validator.ShouldHaveChildValidator(x => x, typeof(CommonBlogCommandValidator));
         }
     }
 }

--- a/FoxHound.App/Blogs/Common/CommonBlogCommandValidator.cs
+++ b/FoxHound.App/Blogs/Common/CommonBlogCommandValidator.cs
@@ -1,0 +1,18 @@
+﻿using FluentValidation;
+
+namespace FoxHound.App.Blogs.Common
+{
+    public class CommonBlogCommandValidator : AbstractValidator<IBlogCommand>
+    {
+        public CommonBlogCommandValidator()
+        {
+            RuleFor(x => x.Title)
+                .NotEmpty().WithMessage("Title is required")
+                .MaximumLength(128).WithMessage("Title must be less than or equal to {MaxLength} characters");
+
+            RuleFor(x => x.Owner)
+                .NotEmpty().WithMessage("Owner is required")
+                .MaximumLength(20).WithMessage("Owner must be less than or equal to {MaxLength} characters");
+        }
+    }
+}

--- a/FoxHound.App/Blogs/Common/IBlogCommand.cs
+++ b/FoxHound.App/Blogs/Common/IBlogCommand.cs
@@ -1,0 +1,8 @@
+﻿namespace FoxHound.App.Blogs.Common
+{
+    public interface IBlogCommand
+    {
+        string Title { get; set; }
+        string Owner { get; set; }
+    }
+}

--- a/FoxHound.App/Blogs/CreateBlog/CreateBlogCommand.cs
+++ b/FoxHound.App/Blogs/CreateBlog/CreateBlogCommand.cs
@@ -1,8 +1,9 @@
-﻿using MediatR;
+﻿using FoxHound.App.Blogs.Common;
+using MediatR;
 
 namespace FoxHound.App.Blogs.CreateBlog
 {
-    public class CreateBlogCommand : IRequest<int>
+    public class CreateBlogCommand : IRequest<int>, IBlogCommand
     {
         public string Title { get; set; } = string.Empty;
         public string Owner { get; set; } = string.Empty;

--- a/FoxHound.App/Blogs/CreateBlog/CreateBlogCommandValidator.cs
+++ b/FoxHound.App/Blogs/CreateBlog/CreateBlogCommandValidator.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using FoxHound.App.Blogs.Common;
 
 namespace FoxHound.App.Blogs.CreateBlog
 {
@@ -6,13 +7,7 @@ namespace FoxHound.App.Blogs.CreateBlog
     {
         public CreateBlogCommandValidator()
         {
-            RuleFor(x => x.Title)
-                .NotEmpty().WithMessage("Title is required")
-                .MaximumLength(128).WithMessage("Title must be less than or equal to {MaxLength} characters");
-
-            RuleFor(x => x.Owner)
-                .NotEmpty().WithMessage("Owner is required")
-                .MaximumLength(20).WithMessage("Owner must be less than or equal to {MaxLength} characters");
+            RuleFor(x => x).SetValidator(new CommonBlogCommandValidator());
         }
     }
 }

--- a/FoxHound.App/Blogs/CreateBlog/CreateBlogCommandValidator.cs
+++ b/FoxHound.App/Blogs/CreateBlog/CreateBlogCommandValidator.cs
@@ -1,13 +1,31 @@
 ﻿using FluentValidation;
 using FoxHound.App.Blogs.Common;
+using FoxHound.App.Data;
+using Microsoft.EntityFrameworkCore;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace FoxHound.App.Blogs.CreateBlog
 {
     public class CreateBlogCommandValidator : AbstractValidator<CreateBlogCommand>
     {
-        public CreateBlogCommandValidator()
+        private readonly IFoxHoundData _foxHoundData;
+
+        public CreateBlogCommandValidator(IFoxHoundData foxHoundData)
         {
+            _foxHoundData = foxHoundData;
+
             RuleFor(x => x).SetValidator(new CommonBlogCommandValidator());
+
+            RuleFor(x => x.Owner)
+                .MustAsync(OwnerNotAlreadyInUse).WithMessage("Owner already in use for a Blog");
+        }
+
+        private async Task<bool> OwnerNotAlreadyInUse(CreateBlogCommand command, string ownerName, CancellationToken cancellationToken)
+        {
+            bool isOwnerInUse = await _foxHoundData.Blogs.AnyAsync(x => x.Owner.ToUpper() == ownerName.ToUpper(), cancellationToken);
+
+            return !isOwnerInUse;
         }
     }
 }

--- a/FoxHound.App/Blogs/UpdateBlog/UpdateBlogCommand.cs
+++ b/FoxHound.App/Blogs/UpdateBlog/UpdateBlogCommand.cs
@@ -1,8 +1,9 @@
-﻿using MediatR;
+﻿using FoxHound.App.Blogs.Common;
+using MediatR;
 
 namespace FoxHound.App.Blogs.UpdateBlog
 {
-    public class UpdateBlogCommand : IRequest
+    public class UpdateBlogCommand : IRequest, IBlogCommand
     {
         public int BlogId { get; set; }
         public string Title { get; set; } = string.Empty;

--- a/FoxHound.App/Blogs/UpdateBlog/UpdateBlogCommandValidator.cs
+++ b/FoxHound.App/Blogs/UpdateBlog/UpdateBlogCommandValidator.cs
@@ -1,16 +1,34 @@
 ﻿using FluentValidation;
 using FoxHound.App.Blogs.Common;
+using FoxHound.App.Data;
+using Microsoft.EntityFrameworkCore;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace FoxHound.App.Blogs.UpdateBlog
 {
     public class UpdateBlogCommandValidator : AbstractValidator<UpdateBlogCommand>
     {
-        public UpdateBlogCommandValidator()
+        private readonly IFoxHoundData _foxHoundData;
+
+        public UpdateBlogCommandValidator(IFoxHoundData foxHoundData)
         {
+            _foxHoundData = foxHoundData;
+
             RuleFor(x => x.BlogId)
                 .NotEmpty().WithMessage("Blog Id is required");
 
             RuleFor(x => x).SetValidator(new CommonBlogCommandValidator());
+
+            RuleFor(x => x.Owner)
+                .MustAsync(OwnerNotAlreadyInUse).WithMessage("Owner already in use for a Blog");
+        }
+
+        private async Task<bool> OwnerNotAlreadyInUse(UpdateBlogCommand command, string ownerName, CancellationToken cancellationToken)
+        {
+            bool isOwnerInUse = await _foxHoundData.Blogs.AnyAsync(x => x.BlogId != command.BlogId && x.Owner.ToUpper() == ownerName.ToUpper(), cancellationToken);
+
+            return !isOwnerInUse;
         }
     }
 }

--- a/FoxHound.App/Blogs/UpdateBlog/UpdateBlogCommandValidator.cs
+++ b/FoxHound.App/Blogs/UpdateBlog/UpdateBlogCommandValidator.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using FoxHound.App.Blogs.Common;
 
 namespace FoxHound.App.Blogs.UpdateBlog
 {
@@ -9,13 +10,7 @@ namespace FoxHound.App.Blogs.UpdateBlog
             RuleFor(x => x.BlogId)
                 .NotEmpty().WithMessage("Blog Id is required");
 
-            RuleFor(x => x.Title)
-                .NotEmpty().WithMessage("Title is required")
-                .MaximumLength(128).WithMessage("Title must be less than or equal to {MaxLength} characters");
-
-            RuleFor(x => x.Owner)
-                .NotEmpty().WithMessage("Owner is required")
-                .MaximumLength(20).WithMessage("Owner must be less than or equal to {MaxLength} characters");
+            RuleFor(x => x).SetValidator(new CommonBlogCommandValidator());
         }
     }
 }


### PR DESCRIPTION
Common validators for add and update blog moved to a common blog validator.

***CHECK/CONFIRM*** Verify I am updating this correctly in the Test classes, by using a Common Base validator this will reduce the checks and I can make a call directly to the base validator using "ShouldHaveChildValidator" passing it the "CommonBlogCommandValidator". 